### PR TITLE
feat: make fields public in token macro implementation

### DIFF
--- a/lachs_derive/src/token.rs
+++ b/lachs_derive/src/token.rs
@@ -32,7 +32,7 @@ pub fn impl_token_macro(item: syn::Item, attrs: Punctuated<Ident, Comma>) -> Tok
             let (fields, insertions) = if *attr_ident == "terminal" {
                 (
                     quote! {
-                        position: lachs::Span,
+                        pub position: lachs::Span,
                     },
                     {
                         let literal = literal.value();
@@ -45,8 +45,8 @@ pub fn impl_token_macro(item: syn::Item, attrs: Punctuated<Ident, Comma>) -> Tok
             } else if *attr_ident == "literal" {
                 (
                     quote! {
-                        position: lachs::Span,
-                        value: String,
+                        pub position: lachs::Span,
+                        pub value: String,
                     },
                     {
                         let literal = literal.value();


### PR DESCRIPTION
Update the `impl_token_macro` function to make the `position` and 
`value` fields public. This change enhances accessibility for 
users of the macro, allowing them to interact with these fields 
directly in their implementations.